### PR TITLE
Update master pom and lesson-converter/pom to use webgoat 7.0-SNAPSHOT

### DIFF
--- a/lesson-converter/pom.xml
+++ b/lesson-converter/pom.xml
@@ -10,7 +10,7 @@
         <dependency>
             <groupId>org.owasp.webgoat</groupId>
             <artifactId>webgoat-container</artifactId>
-            <version>6.1.0</version>
+            <version>7.0-SNAPSHOT</version>
             <type>jar</type>
         </dependency>
         <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
             <dependency>
                 <groupId>org.owasp.webgoat</groupId>
                 <artifactId>webgoat-container</artifactId>
-                <version>6.1.0</version>
+                <version>7.0-SNAPSHOT</version>
                 <type>jar</type>
             </dependency>
         </dependencies>


### PR DESCRIPTION
When trying to build the Lessons with the most current versions of the Server, it complained about the container version.

Updating 2 pom's to reflect the snapshot versions of the webgoat-container.