### PR TITLE
Changes webgoat-container dep version to 7.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -99,7 +99,7 @@
             <dependency>
                 <groupId>org.owasp.webgoat</groupId>
                 <artifactId>webgoat-container</artifactId>
-                <version>7.0-SNAPSHOT</version>
+                <version>7.1-SNAPSHOT</version>
                 <type>jar</type>
                 <scope>provided</scope>
             </dependency>


### PR DESCRIPTION
Changes webgoat-container dependency version to 7.1, to be in line with
the WebGoat repository. Fixes a dependency error.

I ran into this dependency error when following the instructions given in the README.