### PR TITLE
HTTP-basics number of requests before completion (and ZAP link)

### DIFF
--- a/http-basics/src/main/java/org/owasp/webgoat/plugin/HttpBasics.java
+++ b/http-basics/src/main/java/org/owasp/webgoat/plugin/HttpBasics.java
@@ -49,6 +49,7 @@ import java.util.List;
 public class HttpBasics extends LessonAdapter {
 
     private final static String PERSON = "person";
+    private int requestsSinceLastComplete = 0;
 
     /**
      * Description of the Method
@@ -57,6 +58,7 @@ public class HttpBasics extends LessonAdapter {
      * @return Description of the Return Value
      */
     protected Element createContent(WebSession s) {
+        requestsSinceLastComplete++;
         ElementContainer ec = new ElementContainer();
 
         StringBuffer person = null;
@@ -77,11 +79,16 @@ public class HttpBasics extends LessonAdapter {
             e.printStackTrace();
         }
 
-        if (!person.toString().equals("") && getLessonTracker(s).getNumVisits() > 3) {
+        if (!person.toString().equals("") && approvedNumberOfAttempts()) {
             makeSuccess(s);
+            requestsSinceLastComplete = 0;
         }
 
         return (ec);
+    }
+
+    private boolean approvedNumberOfAttempts() {
+        return requestsSinceLastComplete > 2;
     }
 
     /**
@@ -93,11 +100,19 @@ public class HttpBasics extends LessonAdapter {
         List<String> hints = new ArrayList<String>();
         hints.add("Type in your name and press 'go'");
         hints.add("Turn on Show Parameters or other features");
-        hints.add("Try to intercept the request with OWASP ZAP");
+        hints.add("Try to intercept the request with <a href='https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project' title='Link to ZAP'>OWASP ZAP</a>");
         hints.add("Press the Show Lesson Plan button to view a lesson summary");
         hints.add("Press the Show Solution button to view a lesson solution");
 
         return hints;
+    }
+
+    /**
+     * Resets the request counter when the lesson is restarted
+     */
+    @Override
+    public void restartLesson() {
+        requestsSinceLastComplete = 0;
     }
 
     /**

--- a/http-basics/src/main/resources/plugin/HttpBasics/lessonPlans/en/HttpBasics.html
+++ b/http-basics/src/main/resources/plugin/HttpBasics/lessonPlans/en/HttpBasics.html
@@ -23,5 +23,5 @@ After sending the request and headers, the client may send additional data. This
 Enter your name in the input field below and press "Go!" to submit. The server will accept the request, reverse the input and display it back to the user, illustrating the basics of handling an HTTP request.
 <br/><br/>
 The user should become familiar with the features of WebGoat by manipulating the above 
-buttons to view hints, show the HTTP request parameters, the HTTP request cookies, and the Java source code. You may also try using OWASP Zed Attack Proxy for the first time.
+buttons to view hints, show the HTTP request parameters, the HTTP request cookies, and the Java source code. You may also try using <a href='https://www.owasp.org/index.php/OWASP_Zed_Attack_Proxy_Project' title='Link to ZAP'>OWASP Zed Attack Proxy</a> for the first time.
 <!-- Stop Instructions -->


### PR DESCRIPTION
Fix webgoat/webgoat#178 to change number of requests to 2 before completion. Also fixes a bug where the lesson would only need one submission if it had been previously completed and restarted.