### PR TITLE
Fix jsp file path in "LAB: Client Side Filtering"

### DIFF
--- a/client-side-filtering/src/main/java/org/owasp/webgoat/plugin/ClientSideFiltering.java
+++ b/client-side-filtering/src/main/java/org/owasp/webgoat/plugin/ClientSideFiltering.java
@@ -156,7 +156,7 @@ public class ClientSideFiltering extends SequentialLessonAdapter
          * 1. If clientSideFiltering.jsp has an XPath filter to
          *    limit the data being returned.
          */
-        String file = LessonUtil.getLessonDirectory(s, this) + "jsp/clientSideFiltering.jsp";
+        String file = LessonUtil.getLessonDirectory(s, this) + "/jsp/clientSideFiltering.jsp";
         String content = getFileContent(file);
 
         if (content.indexOf("[Managers/Manager/text()") != -1)


### PR DESCRIPTION
In the method .doStage2(), it needs to open "jsp/clientSideFiltering.jsp"
under the lesson directory to check whether the user fixed the bug correctly.

The original version will always failed because of missing the seperator "/"
while concating the file path.