### PR TITLE
Don't use Snapshot target in master

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,7 +8,7 @@
     <version>1.0</version>
 
     <properties>
-        <webgoat.container.version>7.1-SNAPSHOT</webgoat.container.version>
+        <webgoat.container.version>7.1</webgoat.container.version>
     </properties>
 
     <modules>


### PR DESCRIPTION
This fixes webgoat/webgoat#281 where the build error where the lessons are not able to build since they webgoat container has the wrong version.

Note that the build also depends on fixing webgoat/webgoat#247 in the master branch.

